### PR TITLE
Indentation guides

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -603,6 +603,9 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
         request::DocumentSymbolRequest::METHOD => {
             document_symbol::text_document_document_symbol(meta, ctx);
         }
+        "kakoune/indent-guides" => {
+            document_symbol::indent_guides(meta, params, ctx);
+        }
         "kakoune/next-or-previous-symbol" => {
             document_symbol::next_or_prev_symbol(meta, params, ctx);
         }

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -23,6 +23,9 @@ use std::path::{Path, PathBuf};
 use unicode_width::UnicodeWidthStr;
 use url::Url;
 
+pub fn indent_guides(_: EditorMeta, _: EditorParams, _: &mut Context) {
+    todo!()
+}
 pub fn text_document_document_symbol(meta: EditorMeta, ctx: &mut Context) {
     let eligible_servers: Vec<_> = ctx
         .language_servers

--- a/src/types.rs
+++ b/src/types.rs
@@ -282,6 +282,14 @@ pub struct NextOrPrevSymbolParams {
     pub hover: bool,
 }
 
+#[derive(Clone, Default, Deserialize, Debug)]
+#[serde(default)]
+pub struct IndentGuidesParams {
+    pub skip: usize,
+    pub characters: Vec<String>,
+    pub position_line: u32,
+}
+
 #[derive(Clone, Deserialize, Debug)]
 pub struct GotoSymbolParams {
     pub goto_symbol: Option<String>,


### PR DESCRIPTION
Adds indentation guides highlighting the scope of the functions/methods/classes/etc.

The implementation depends on the document symbols LSP API.

* Adds 2 new commands similar to existing commands.
    - `lsp-indent-guides-(enable|disable) {buffer|global|window}`.
* Adds 2 new faces.
    - `IndentGuide` and `IndentGuideFocused`, defaults `comment` and `MatchingChar`.
* Nested characters can be customized according to their level.
Picks the last one if the scope is deeper than the amount of characters.
    - `lsp_indent_guides_characters`, defaults to `│ ┆ ┊ ⸽`.
* Adds an option to skip specified levels of nestedness.
    - `lsp_indent_guides_skip`, defaults to `0`.
* Adds an option to disable highlighting of the current scope.
    - `lsp_indent_guides_highlight_focused`, defaults to `true`.

**NOTE**:
Unfortunately, it can not render on black lines due to
Kakoune `replace-range` being unable to render on blank spaces.
It's possible to make it render on blank lines by keeping track and merging specs on the same line,
however it's not trivial to implement.

I would really like to render on blank lines as it improves the UX quite well.
I was able to implement tracking and merging, but performance-wise it was pretty horrible,
so I decided to publish a simpler solution with a potential for further improvements.

And also likely will break if indentation does not follow the scope,
e.g. with multiline strings in some languages.

Reviews and advices are welcomed.

Screenshot before:
![image](https://github.com/kak-lsp/kak-lsp/assets/12570166/41ee1a8d-bb73-4f7e-b1eb-4f22245f34fc)


Screenshot after:
![image](https://github.com/kak-lsp/kak-lsp/assets/12570166/af082fc1-2f54-4fa7-99fa-e979b86b3870)

