### PR TITLE
Sticky Contexts

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -33,6 +33,8 @@ set-face global ReferenceBind +u@Reference
 # Face for inlay hints.
 set-face global InlayHint cyan+d
 set-face global InlayCodeLens cyan+d
+# Face for sticky contexts
+set-face global StickyContexts +Fiud@Default
 
 # Options for tuning LSP behaviour.
 
@@ -161,6 +163,9 @@ Capture groups must be:
     3: optional column
     4: optional message
 } regex lsp_location_format ^\h*\K([^:\n]+):(\d+)\b(?::(\d+)\b)?(?::([^\n]+))
+
+declare-option -docstring "Number of sticky contexts to skip from the top" int lsp_sticky_contexts_skip 0
+declare-option -docstring "Max number of sticky contexts to show" int lsp_sticky_contexts_max 4
 
 # Callback functions. May override these.
 
@@ -340,6 +345,7 @@ declare-option -hidden range-specs cquery_semhl
 declare-option -hidden int lsp_timestamp -1
 declare-option -hidden range-specs lsp_references
 declare-option -hidden range-specs lsp_semantic_tokens
+declare-option -hidden range-specs lsp_sticky_contexts
 declare-option -hidden range-specs lsp_inlay_hints
 declare-option -hidden range-specs lsp_inlay_code_lenses
 declare-option -hidden line-specs lsp_code_lenses 0 '0| '
@@ -1415,6 +1421,37 @@ incomingOrOutgoing = $1
 " | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
+define-command -hidden lsp-sticky-contexts-request -docstring "request updating lsp_sticky_contexts for the buffer" %{
+  nop %sh{
+    window_start_line="$(echo $kak_window_range | cut -d' ' -f1)"
+
+    (printf %s "
+session  = \"${kak_session}\"
+buffile  = \"${kak_buffile}\"
+filetype = \"${kak_opt_filetype}\"
+version  = ${kak_timestamp:-0}
+method   = \"kakoune/sticky-contexts\"
+$([ -z ${kak_hook_param+x} ] || echo hook = true)
+[params]
+skip = $kak_opt_lsp_sticky_contexts_skip
+max = $kak_opt_lsp_sticky_contexts_max
+position_line = $kak_cursor_line
+window_start_line = $window_start_line
+window_width = $kak_window_width
+" | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
+}
+
+define-command lsp-sticky-contexts-enable -params 1 -docstring "lsp-sticky-contexts-enable <scope>: enable sticky contexts for <scope>" %{
+  add-highlighter -override "%arg{1}/lsp_sticky_contexts" replace-ranges lsp_sticky_contexts
+  hook -group lsp-sticky-contexts %arg{1} BufReload .* lsp-sticky-contexts-request
+  hook -group lsp-sticky-contexts %arg{1} NormalIdle .* lsp-sticky-contexts-request
+  hook -group lsp-sticky-contexts %arg{1} InsertIdle .* lsp-sticky-contexts-request
+} -shell-script-candidates %{ printf '%s\n' buffer global window }
+
+define-command lsp-sticky-contexts-disable -params 1 -docstring "lsp-sticky-contexts-disable <scope>: disable sticky contexts for <scope>" %{
+  remove-highlighter "%arg{1}/lsp_sticky_contexts"
+  remove-hooks %arg{1} lsp-sticky-contexts
+} -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 define-command -hidden lsp-inlay-hints -docstring "lsp-inlay-hints: request inlay hints" %{
     declare-option -hidden int lsp_inlay_hints_timestamp -1

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -603,6 +603,9 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
         request::DocumentSymbolRequest::METHOD => {
             document_symbol::text_document_document_symbol(meta, ctx);
         }
+        "kakoune/sticky-contexts" => {
+            document_symbol::sticky_contexts(meta, params, ctx);
+        }
         "kakoune/next-or-previous-symbol" => {
             document_symbol::next_or_prev_symbol(meta, params, ctx);
         }

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -1,10 +1,13 @@
 use crate::capabilities::{attempt_server_capability, CAPABILITY_DOCUMENT_SYMBOL};
 use crate::language_features::goto::edit_at_range;
 use crate::language_features::hover::editor_hover;
+use crate::position::get_line;
+use std::convert::TryFrom;
+
 use crate::markup::escape_kakoune_markup;
 use crate::position::{
-    get_kakoune_position_with_fallback, get_kakoune_range_with_fallback, get_lsp_position,
-    kakoune_position_to_lsp, lsp_range_to_kakoune, parse_kakoune_range,
+    get_kakoune_position_with_fallback, get_kakoune_range, get_kakoune_range_with_fallback,
+    get_lsp_position, kakoune_position_to_lsp, lsp_range_to_kakoune, parse_kakoune_range,
 };
 use crate::types::*;
 use crate::util::*;
@@ -24,7 +27,143 @@ use unicode_width::UnicodeWidthStr;
 use url::Url;
 
 pub fn sticky_contexts(meta: EditorMeta, editor_params: EditorParams, ctx: &mut Context) {
-    todo!()
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|srv| attempt_server_capability(*srv, &meta, CAPABILITY_DOCUMENT_SYMBOL))
+        .collect();
+    let req_params = eligible_servers
+        .into_iter()
+        .map(|(server_name, _)| {
+            (
+                server_name.clone(),
+                vec![DocumentSymbolParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                    },
+                    partial_result_params: Default::default(),
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    let params = StickyContextsParams::deserialize(editor_params).unwrap();
+    ctx.call::<DocumentSymbolRequest, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx: &mut Context, meta, results| {
+            match results.into_iter().find(|(_, v)| v.is_some()) {
+                Some((server_name, Some(DocumentSymbolResponse::Nested(symbols))))
+                    if !symbols.is_empty() =>
+                {
+                    let server = &ctx.language_servers[&server_name];
+                    let mut range_specs = String::default();
+                    let document = if let Some(document) = ctx.documents.get(&meta.buffile) {
+                        document
+                    } else {
+                        return;
+                    };
+                    let mut filename_path = PathBuf::default();
+                    let symbol = &symbols[0];
+                    let filename = symbol_filename(&meta, symbol, &mut filename_path).to_string();
+                    sticky_contexts_calc_ranges(
+                        &symbols,
+                        &params,
+                        ctx,
+                        server,
+                        document,
+                        filename.as_str(),
+                        &mut range_specs,
+                        0,
+                    );
+                    let version = meta.version;
+                    let command =
+                        formatdoc!("set-option buffer lsp_sticky_contexts {version} {range_specs}");
+                    let command = format!(
+                        "evaluate-commands -buffer {} -- {}",
+                        editor_quote(&meta.buffile),
+                        editor_quote(&command)
+                    );
+                    ctx.exec(meta, command);
+                }
+                Some((_, Some(DocumentSymbolResponse::Nested(_)))) => {
+                    return;
+                }
+                Some((_, Some(DocumentSymbolResponse::Flat(_)))) => {
+                    return;
+                }
+                Some((_, None)) => {
+                    return;
+                }
+                None => {
+                    return;
+                }
+            };
+        },
+    );
+}
+
+fn sticky_contexts_calc_ranges(
+    symbols: &[DocumentSymbol],
+    params: &StickyContextsParams,
+    ctx: &Context,
+    server: &ServerSettings,
+    document: &Document,
+    filename: &str,
+    acc: &mut String,
+    level: usize,
+) {
+    let reached_max_level = level == params.max;
+    if reached_max_level {
+        return;
+    };
+    for symbol in symbols {
+        let should_skip = level < params.skip;
+        let symbol_range = get_kakoune_range(server, filename, &symbol.range, ctx).unwrap();
+        let symbol_selection_range =
+            get_kakoune_range(server, filename, &symbol.selection_range, ctx).unwrap();
+        let is_inside = {
+            let is_after_symbol_start = symbol_range.start.line <= params.position_line;
+            let is_before_symbol_end = params.position_line <= symbol_range.end.line;
+            is_after_symbol_start && is_before_symbol_end
+        };
+        let is_invisible = params.window_start_line > symbol_range.start.line;
+        if is_inside {
+            if !should_skip && is_invisible {
+                let source_line_content = &get_line(
+                    (symbol_selection_range.start.line - 1).try_into().unwrap(),
+                    &document.text,
+                )
+                .to_string()
+                .replace("\n", "");
+                let source_line_content = escape_tuple_element(source_line_content.as_str());
+                let source_line_content = escape_kakoune_markup(source_line_content.as_str());
+                let target_line: usize =
+                    usize::try_from(params.window_start_line).unwrap() + level + 1;
+                let target_line_content =
+                    &get_line((target_line - 1).try_into().unwrap(), &document.text)
+                        .to_string()
+                        .replace("\n", "");
+                let width = target_line_content.as_bytes().len();
+                let spec =
+                    &format!("{target_line}.1+{width}|{{StickyContexts}}{source_line_content}");
+                let spec = editor_quote(spec);
+                acc.push_str(spec.as_str());
+                acc.push(' ');
+            };
+            sticky_contexts_calc_ranges(
+                symbol.children(),
+                params,
+                ctx,
+                server,
+                document,
+                filename,
+                acc,
+                level + 1,
+            );
+            break;
+        }
+    }
 }
 
 pub fn text_document_document_symbol(meta: EditorMeta, ctx: &mut Context) {

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -23,6 +23,10 @@ use std::path::{Path, PathBuf};
 use unicode_width::UnicodeWidthStr;
 use url::Url;
 
+pub fn sticky_contexts(meta: EditorMeta, editor_params: EditorParams, ctx: &mut Context) {
+    todo!()
+}
+
 pub fn text_document_document_symbol(meta: EditorMeta, ctx: &mut Context) {
     let eligible_servers: Vec<_> = ctx
         .language_servers

--- a/src/types.rs
+++ b/src/types.rs
@@ -282,6 +282,16 @@ pub struct NextOrPrevSymbolParams {
     pub hover: bool,
 }
 
+#[derive(Clone, Default, Deserialize, Debug)]
+#[serde(default)]
+pub struct StickyContextsParams {
+    pub skip: usize,
+    pub max: usize,
+    pub position_line: u32,
+    pub window_start_line: u32,
+    pub window_width: usize,
+}
+
 #[derive(Clone, Deserialize, Debug)]
 pub struct GotoSymbolParams {
     pub goto_symbol: Option<String>,


### PR DESCRIPTION
Adds sticky contexts feature.

Example:
![image](https://github.com/kak-lsp/kak-lsp/assets/12570166/cd2184c7-96c1-4206-aa2f-58261e2ef367)

* new face `StickyContexts`, defaults to `default+Fbuid`.
* new option `lsp_sticky_contexts_skip`, defaults to 0.
* new commands `lsp-sticky-contexts-(enable|disable)` similar to existing commands.

**UPDATE:**
* added additional option `lsp_sticky_contexts_max`, defaults to 4.