### PR TITLE
fix: return the whole settings when section is empty

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -32,8 +32,7 @@ command = "clangd"
 filetypes = ["clojure"]
 roots = ["project.clj", ".git", ".hg"]
 command = "clojure-lsp"
-settings_section = "_"
-[language_server.clojure-lsp.settings._]
+[language_server.clojure-lsp.settings]
 # See https://clojure-lsp.io/settings/#all-settings
 # source-paths-ignore-regex = ["resources.*", "target.*"]
 
@@ -76,8 +75,7 @@ filetypes = ["scala"]
 roots = ["build.sbt", ".scala-build"]
 command = "metals"
 args = ["-Dmetals.extensions=false"]
-settings_section = "metals"
-[language_server.metals.settings.metals]
+[language_server.metals.settings]
 icons = "unicode"
 isHttpEnabled = true
 statusBarProvider = "log-message"
@@ -113,8 +111,7 @@ command = "jdtls"
 filetypes = ["elixir"]
 roots = ["mix.exs"]
 command = "elixir-ls"
-settings_section = "elixirLS"
-[language_server.elixir-ls.settings.elixirLS]
+[language_server.elixir-ls.settings]
 # See https://github.com/elixir-lsp/elixir-ls/blob/master/apps/language_server/lib/language_server/server.ex
 # dialyzerEnable = true
 
@@ -123,8 +120,7 @@ filetypes = ["elm"]
 roots = ["elm.json"]
 command = "elm-language-server"
 args = ["--stdio"]
-settings_section = "elmLS"
-[language_server.elm-language-server.settings.elmLS]
+[language_server.elm-language-server.settings]
 # See https://github.com/elm-tooling/elm-language-server#server-settings
 runtime = "node"
 elmPath = "elm"
@@ -148,7 +144,7 @@ command = "erlang_ls"
 filetypes = ["go"]
 roots = ["Gopkg.toml", "go.mod", ".git", ".hg"]
 command = "gopls"
-[language_server.gopls.settings.gopls]
+[language_server.gopls.settings]
 # See https://github.com/golang/tools/blob/master/gopls/doc/settings.md
 # "build.buildFlags" = []
 
@@ -157,8 +153,7 @@ filetypes = ["haskell"]
 roots = ["hie.yaml", "cabal.project", "Setup.hs", "stack.yaml", "*.cabal"]
 command = "haskell-language-server-wrapper"
 args = ["--lsp"]
-settings_section = "_"
-[language_server.haskell-language-server.settings._]
+[language_server.haskell-language-server.settings]
 # See https://haskell-language-server.readthedocs.io/en/latest/configuration.html
 # haskell.formattingProvider = "ormolu"
 
@@ -167,8 +162,7 @@ filetypes = ["html"]
 roots = ["package.json"]
 command = "vscode-html-languageserver"
 args = ["--stdio"]
-settings_section = "_"
-[language_server.html-language-server.settings._]
+[language_server.html-language-server.settings]
 # quotePreference = "single"
 # javascript.format.semicolons = "insert"
 
@@ -177,8 +171,7 @@ filetypes = ["php"]
 roots = [".htaccess", "composer.json"]
 command = "intelephense"
 args = ["--stdio"]
-settings_section = "intelephense"
-[language_server.intelephense.settings.intelephense]
+[language_server.intelephense.settings]
 storagePath = "/tmp/intelephense"
 
 [language_server.json-language-server]
@@ -228,18 +221,17 @@ args = [
 [language_server.julia-language-server.settings]
 # See https://github.com/julia-vscode/LanguageServer.jl/blob/master/src/requests/workspace.jl
 # Format options. See https://github.com/julia-vscode/DocumentFormat.jl/blob/master/src/DocumentFormat.jl
-# "julia.format.indent" = 4
+# "format.indent" = 4
 # Lint options. See https://github.com/julia-vscode/StaticLint.jl/blob/master/src/linting/checks.jl
-# "julia.lint.call" = true
+# "lint.call" = true
 # Other options, see https://github.com/julia-vscode/LanguageServer.jl/blob/master/src/requests/workspace.jl
-# "julia.lint.run" = "true"
+# "lint.run" = "true"
 
 [language_server.lua-language-server]
 filetypes = ["lua"]
 roots = [".git", ".hg"]
 command = "lua-language-server"
-settings_section = "Lua"
-[language_server.lua-language-server.settings.Lua]
+[language_server.lua-language-server.settings]
 # See https://github.com/sumneko/vscode-lua/blob/master/setting/schema.json
 # diagnostics.enable = true
 
@@ -275,8 +267,7 @@ args = ["--stdio"]
 filetypes = ["python"]
 roots = ["requirements.txt", "setup.py", ".git", ".hg"]
 command = "pylsp"
-settings_section = "_"
-[language_server.pylsp.settings._]
+[language_server.pylsp.settings]
 # See https://github.com/python-lsp/python-lsp-server#configuration
 # pylsp.configurationSources = ["flake8"]
 pylsp.plugins.jedi_completion.include_params = true
@@ -291,8 +282,7 @@ pylsp.plugins.jedi_completion.include_params = true
 # filetypes = ["python"]
 # roots = ["requirements.txt", "setup.py", ".git", ".hg"]
 # command = "ruff-lsp"
-# settings_section = "_"
-# [language_server.ruff.settings._.globalSettings]
+# [language_server.ruff.settings.globalSettings]
 # organizeImports = true
 # fixAll = true
 
@@ -351,7 +341,7 @@ args = [
         fi
     """,
 ]
-[language_server.rust-analyzer.settings.rust-analyzer]
+[language_server.rust-analyzer.settings]
 # See https://rust-analyzer.github.io/manual.html#configuration
 hoverActions.enable = false # kak-lsp doesn't support this at the moment
 # cargo.features = []
@@ -361,8 +351,7 @@ filetypes = ["ruby"]
 roots = ["Gemfile"]
 command = "solargraph"
 args = ["stdio"]
-settings_section = "_"
-[language_server.solargraph.settings._]
+[language_server.solargraph.settings]
 # See https://github.com/castwide/solargraph/blob/master/lib/solargraph/language_server/host.rb
 # diagnostics = false
 
@@ -371,7 +360,7 @@ filetypes = ["terraform"]
 roots = ["*.tf"]
 command = "terraform-ls"
 args = ["serve"]
-[language_server.terraform-ls.settings.terraform-ls]
+[language_server.terraform-ls.settings]
 # See https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md
 # rootModulePaths = []
 
@@ -379,7 +368,7 @@ args = ["serve"]
 filetypes = ["latex"]
 roots = [".git", ".hg"]
 command = "texlab"
-[language_server.texlab.settings.texlab]
+[language_server.texlab.settings]
 # See https://github.com/latex-lsp/texlab/wiki/Configuration
 #
 # Preview configuration for zathura with SyncTeX search.
@@ -408,8 +397,7 @@ filetypes = ["javascript", "typescript"]
 roots = ["package.json", "tsconfig.json", "jsconfig.json", ".git", ".hg"]
 command = "typescript-language-server"
 args = ["--stdio"]
-settings_section = "_"
-[language_server.typescript-language-server.settings._]
+[language_server.typescript-language-server.settings]
 # quotePreference = "double"
 # typescript.format.semicolons = "insert"
 
@@ -419,7 +407,7 @@ roots = [".git", ".hg"]
 command = "yaml-language-server"
 args = ["--stdio"]
 settings_section = "yaml"
-[language_server.yaml-language-server.settings.yaml]
+[language_server.yaml-language-server.settings]
 # See https://github.com/redhat-developer/yaml-language-server#language-server-settings
 # Defaults are at https://github.com/redhat-developer/yaml-language-server/blob/master/src/yamlSettings.ts
 # format.enable = true

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -59,7 +59,14 @@ pub fn configured_section(
             .language_server
             .get(server_name)
             .and_then(|cfg| cfg.settings_section.as_ref())
-            .and_then(|section| settings.get(section).cloned())
+            // if settings_section is not set, return the whole settings object
+            .and_then(|section| {
+                if section.is_empty() {
+                    Some(settings.clone())
+                } else {
+                    settings.get(section).cloned()
+                }
+            })
     })
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -89,7 +89,14 @@ pub fn configuration(
                 // Tests indicate the former.
                 .map(|section| match &settings {
                     None => Value::Null,
-                    Some(settings) => settings.get(section).unwrap_or(&Value::Null).clone(),
+                    Some(settings) => {
+                        // if the section is empty, return the whole settings
+                        if section.is_empty() {
+                            settings.clone()
+                        } else {
+                            settings.get(section).unwrap_or(&Value::Null).clone()
+                        }
+                    }
                 })
                 .unwrap_or(Value::Null)
         })


### PR DESCRIPTION
When working with the `vscode-eslint-language-server`, it request `workspace/configuration` with a empty section, while kak-lsp respond with `null`.

It's caused by line the following line in `kak-lsp`:

https://github.com/kak-lsp/kak-lsp/blob/117db92b515ea8e826a9bfbda98432a7fd345c25/src/workspace.rs#L92

While the same config works for helix, helix just return the whole settings object when the section is empty.


### Working screenshot


<img width="806" alt="スクリーンショット 2024-02-16 朝9 37 24" src="https://github.com/kak-lsp/kak-lsp/assets/4230968/a1335d55-99a8-4942-8ee6-7c8a1c9a3572">

~~It works on my machine™~~

### Configuration for kak-lsp

```toml
[language_server.eslint]
filetypes = ["javascript", "typescript"]
roots = [".eslintrc", ".eslintrc.json"]
command = "vscode-eslint-language-server"
args = ["--stdio"]
settings_section = "_"

[language_server.eslint.settings._]
codeActionsOnSave = { mode = "all", "source.fixAll.eslint" = true }
format = { enable = true }
nodePath = ""
quiet = false
rulesCustomizations = []
run = "onType"
validate = "on"
experimental = {}
problems = { shortenToSingleLine = false }

[language_server.eslint.settings._.codeAction]
disableRuleComment = { enable = true, location = "separateLine" }
showDocumentation = { enable = false }

```

### Configuration for helix

```toml
[language-server.eslint]
command = "vscode-eslint-language-server"
args = ["--stdio"]

[language-server.eslint.config]
codeActionsOnSave = { mode = "all", "source.fixAll.eslint" = true }
format = { enable = true }
nodePath = ""
quiet = false
rulesCustomizations = []
run = "onType"
validate = "on"
experimental = {}
problems = { shortenToSingleLine = false }

[language-server.eslint.config.codeAction]
disableRuleComment = { enable = true, location = "separateLine" }
showDocumentation = { enable = false }
```
