### PR TITLE
WIP (Blocked): Indentation guides

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -603,6 +603,9 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
         request::DocumentSymbolRequest::METHOD => {
             document_symbol::text_document_document_symbol(meta, ctx);
         }
+        "kakoune/indent-guides" => {
+            document_symbol::indent_guides(meta, params, ctx);
+        }
         "kakoune/next-or-previous-symbol" => {
             document_symbol::next_or_prev_symbol(meta, params, ctx);
         }

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -23,6 +23,9 @@ use std::path::{Path, PathBuf};
 use unicode_width::UnicodeWidthStr;
 use url::Url;
 
+pub fn indent_guides(_: EditorMeta, _: EditorParams, _: &mut Context) {
+    todo!()
+}
 pub fn text_document_document_symbol(meta: EditorMeta, ctx: &mut Context) {
     let eligible_servers: Vec<_> = ctx
         .language_servers

--- a/src/types.rs
+++ b/src/types.rs
@@ -282,6 +282,14 @@ pub struct NextOrPrevSymbolParams {
     pub hover: bool,
 }
 
+#[derive(Clone, Default, Deserialize, Debug)]
+#[serde(default)]
+pub struct IndentGuidesParams {
+    pub skip: usize,
+    pub characters: Vec<String>,
+    pub position_line: u32,
+}
+
 #[derive(Clone, Deserialize, Debug)]
 pub struct GotoSymbolParams {
     pub goto_symbol: Option<String>,


### PR DESCRIPTION
Adds indentation guides highlighting the scope of the functions/methods/classes/etc.

The implementation depends on the document symbols LSP API.

* Adds 2 new commands similar to existing commands.
    - `lsp-indent-guides-(enable|disable) {buffer|global|window}`.
* Adds 2 new faces.
    - `IndentGuide` and `IndentGuideFocused`, defaults `comment` and `MatchingChar`.
* Nested characters can be customized according to their level.
Picks the last one if the scope is deeper than the amount of characters.
    - `lsp_indent_guides_characters`, defaults to `│ ┆ ┊ ⸽`.
* Adds an option to skip specified levels of nestedness.
    - `lsp_indent_guides_skip`, defaults to `1`.

Screenshot before:
![image](https://github.com/kakoune-lsp/kakoune-lsp/assets/12570166/47a1bfee-c481-49c8-aea4-6b1bb8457a8e)

Screenshot after:
![image](https://github.com/kakoune-lsp/kakoune-lsp/assets/12570166/8c95b344-bcbc-44e7-ba15-685dfe4195c2)

