### PR TITLE
lsp-document-symbol: remove redundant filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 - `lsp_hover_max_lines` has been deprecated for `lsp_hover_max_info_lines`. `lsp_hover_max_lines` now defaults to `-1` and when it is `-1` `lsp_hover_max_info_lines` is used to control lines of information in the hover box.
 
 Additions:
+- `lsp-document-symbol` no longer renders the filename in every single line. Commands like `jump-next` and `<ret>` still work as before.
 - `lsp_hover_max_diagnostic_lines` now defaults to 20 which limits the diagnostic lines in the hover box.
 - Various improvements to the compatibility with old Kakoune.
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1757,7 +1757,7 @@ define-command -hidden lsp-show-diagnostics -params 2 -docstring "Render diagnos
         set-option buffer lsp_project_root "%arg{1}/"
         alias buffer jump lsp-diagnostics-jump
         set-register '"' %arg{2}
-        execute-keys Pgg
+        execute-keys Rgg
     }
 }
 
@@ -1768,7 +1768,7 @@ define-command -hidden lsp-show-goto-buffer -params 3 %{
         set-option buffer %opt{lsp_current_line} 0
         set-option buffer lsp_project_root "%arg{2}/"
         set-register '"' %arg{3}
-        execute-keys Pgg
+        execute-keys Rgg
     }
 }
 

--- a/src/language_features/rust_analyzer.rs
+++ b/src/language_features/rust_analyzer.rs
@@ -245,7 +245,10 @@ pub fn run_single(meta: EditorMeta, mut params: ExecuteCommandParams, ctx: &mut 
     let cmd = format!(
         "try {} catch {}",
         editor_quote(&format!("cargo {}", args)),
-        editor_quote(&format!("lsp-with-option makecmd cargo make {}", args))
+        editor_quote(&format!(
+            "try %[require-module make]; lsp-with-option makecmd cargo make {}",
+            args
+        ))
     );
     ctx.exec(
         meta.clone(),


### PR DESCRIPTION
It's always the same and can waste a lot of screen space.

As a quick hack, replace it with % (from %reg{%}), so we don't have
to adjust highlighters - maybe we should?.

Old:

	t/test.go:5:6:  foo (Function)
	t/test.go:9:6:  someFunction (Function)
	t/test.go:26:6: someOtherFunction (Function)

New:

	t/test.go
	%:5:6:  foo (Function)
	%:9:6:  someFunction (Function)
	%:26:6: someOtherFunction (Function)

Shoutout to topisani for the idea and initial implementation.
