### PR TITLE
Update Arch pkg name

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -41,7 +41,7 @@ mv kak-lsp.toml ~/.config/kak-lsp/
 
 ====== Package managers
 
-* Arch Linux: `pacman -S kak-lsp` or https://aur.archlinux.org/packages/kak-lsp-git/[AUR/kak-lsp-git]
+* Arch Linux: `pacman -S kakoune-lsp` or https://aur.archlinux.org/packages/kak-lsp-git/[AUR/kak-lsp-git]
 * Void Linux: `xbps-install -S kak-lsp`
 * Fedora https://copr.fedorainfracloud.org/coprs/atim/kakoune/[Copr]: `sudo dnf copr enable atim/kakoune -y && sudo dnf install kak-lsp`
 


### PR DESCRIPTION
Hello, I have renamed the Arch package, as per the encouragement in the latest changelog :slightly_smiling_face: 

https://archlinux.org/packages/extra/x86_64/kakoune-lsp/