### PR TITLE
run language server in root dir (fixes omnisharp behavior)

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -49,6 +49,7 @@ pub fn start(
             let server_config = &config.language_server[&route.server_name];
             let server_transport = match language_server_transport::start(
                 &route.server_name,
+                &route.root,
                 &server_config.command,
                 &server_config.args,
                 &server_config.envs,

--- a/src/language_server_transport.rs
+++ b/src/language_server_transport.rs
@@ -18,12 +18,13 @@ pub struct LanguageServerTransport {
 
 pub fn start(
     server_name: &str,
+    root: &str,
     cmd: &str,
     args: &[String],
     envs: &HashMap<String, String>,
 ) -> Result<LanguageServerTransport, String> {
     info!(
-        "Starting Language server {server_name} as `{} {}`",
+        "Starting Language server {server_name} as `{} {}` in dir {root}",
         cmd,
         args.join(" ")
     );
@@ -33,6 +34,7 @@ pub fn start(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .current_dir(root)
         .spawn()
     {
         Ok(c) => c,


### PR DESCRIPTION
Somehow Omnisharp seems to always use the cwd as the project root. 
Running the lsp in the current working dir doesn't seem to impact other servers and fixes Omnisharp.

Cheers