### PR TITLE
Scala Metals default config improvements

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -83,6 +83,11 @@ icons = "unicode"
 isHttpEnabled = true
 statusBarProvider = "log-message"
 compilerOptions = { overrideDefFormat = "unicode" }
+inlayHints.hintsInPatternMatch.enable = true
+inlayHints.implicitArguments.enable = true
+inlayHints.implicitConversions.enable = true
+inlayHints.inferredTypes.enable = true
+inlayHints.typeParameters.enable = true
 
 [language_server.nil]
 filetypes = ["nix"]

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -81,7 +81,7 @@ settings_section = "metals"
 [language_server.metals.settings.metals]
 icons = "unicode"
 isHttpEnabled = true
-statusBarProvider = "log-message"
+statusBarProvider = "show-message"
 compilerOptions = { overrideDefFormat = "unicode" }
 inlayHints.hintsInPatternMatch.enable = true
 inlayHints.implicitArguments.enable = true


### PR DESCRIPTION
**Inlay hints:**
Since the [1.3.0](https://scalameta.org/metals/blog/2024/04/15/thalium)
Metals switched from their so-called custom Decoration LSP extension to
LSP-native inlay hints.

These flags are need to be explicitly enabled on the server's side.

**Notifications via `window/showMessage:`**
Turns out `kak-lsp` supports the `window/showMessage`.
It's more convenient than the previous `window/logMessage` as it prints
the status into the Kakoune's status bar.
