### PR TITLE
Fix multiple legacy languages w/ same language server clashing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ fn main() {
                         }
                     }
                     cfg.language_server
-                        .insert(language.command.clone(), language);
+                        .insert(format!("{}:{}", language_id, language.command), language);
                 }
             }
             Ok(cfg)


### PR DESCRIPTION
If a legacy config has multiple languages that use the same language server command (e.g. typescript & javascript both using vtsls), then one of them would overwrite the other, with the winner depending on hash iteration order. To fix this, we can just add the language ID to the configured server name to ensure both entries are separate.

Note that this will end up running an independent language server for each language ID, but that behavior seems to match what pre-v15 did anyway.