### PR TITLE
README: generate the Table of Contents for easier navigation

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,4 +1,6 @@
 = Kakoune Language Server Protocol Client
+:toc: preamble
+:toclevels: 3
 
 This is a https://microsoft.github.io/language-server-protocol/[Language Server Protocol] client for the https://kakoune.org[Kakoune] editor.
 


### PR DESCRIPTION
Github can process the `:toc:` attributes rendering the Table of Contents.
Seems like navigation is a bit easier with the change.