### PR TITLE
gopls: ui.completion prefix is not required

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -139,7 +139,7 @@ hook -group lsp-filetype-go global User LSPDefaultConfig=go %{
             hints.functionTypeParameters = true
             hints.parameterNames = true
             hints.rangeVariableTypes = true
-            ""ui.completion.usePlaceholders"" = true
+            usePlaceholders = true
         "
     }
 }


### PR DESCRIPTION
Tested with gopls 0.16.1