### PR TITLE
minor: julia server configuration

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -222,10 +222,10 @@ hook -group lsp-filetype-json global BufSetOption filetype=json %{
 hook -group lsp-filetype-julia global BufSetOption filetype=julia %{
     set-option buffer lsp_servers %{
         # Requires Julia package "LanguageServer"
-        root_globs = ["Project.toml", ".git", ".hg"]
         # Run: `julia --project=@kak-lsp -e 'import Pkg; Pkg.add("LanguageServer")'` to install it
         # Configuration adapted from https://github.com/neovim/nvim-lspconfig/blob/bcebfac7429cd8234960197dca8de1767f3ef5d3/lua/lspconfig/julials.lua
         [julia-language-server]
+        root_globs = ["Project.toml", ".git", ".hg"]
         command = "julia"
         args = [
             "--startup-file=no",


### PR DESCRIPTION
move `root_globs` option under `[julia-language-server]` heading

The default configuration for the Julia LSP wasn't working for me, but moving the `root_globs` option under the `[julia-language-server]` heading (like all the other server configurations) fixed the issue. Otherwise, I was getting
```
LSP: ERRO Failed to parse %opt{lsp_servers}: invalid type: string "Project.toml", expected a sequence
in `root_globs`
```