### PR TITLE
WIP: allow users to override `SymbolKind` rendering

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -82,6 +82,8 @@ pub struct LanguageServerConfig {
     pub settings_section: Option<String>,
     pub settings: Option<Value>,
     pub offset_encoding: Option<OffsetEncoding>,
+    #[serde(default)]
+    pub symbols_mapping: HashMap<String, String>,
     pub experimental: Option<Value>,
     // This does nothing, but is kept so we can still parse old configs.
     #[allow(dead_code)]


### PR DESCRIPTION
Adds a new optional `[<server_name>.symbols_mapping]` nested table to the `lsp_servers` which is a mapping from `SymbolKind`s to any user-defined strings to make the `lsp-document-symbol` and `lsp-goto-document-symbol` more readable.

More things needed:
* [x] Implement for `lsp-document-symbol`
* [ ] Implement for `lsp-goto-document-symbol`
* [ ] Examples in `rc/servers.kak`
* [ ] Documentation
* [ ] Perhaps, some refactoring

With the new `[rust.symbols_mapping]`:
```
  hook -group lsp-custom-servers global BufSetOption filetype=rust %{
    set-option buffer lsp_servers %{
      [rust]
      filetypes = ["rust"]
      root_globs = ["Cargo.toml"]
      command = "rust-analyzer"
      [rust.symbols_mapping]
      Constant = "const"
      Enum = "enum"
      EnumMember = ""
      Field = ""
      Function = "fn"
      Interface = "trait"
      Method = "fn"
      Module = "mod"
      Object = ""
      Struct = "struct"
      TypeParameter = "type"
    }
  }
```

Before:
```
src/controller.rs
%:46:6:    QuoteState (Enum)
%:47:5:    ├── OutsideArg (EnumMember)
%:48:5:    ├── InsideArg (EnumMember)
%:49:5:    └── InsideArgSQ (EnumMember)
%:52:12:   ParserState (Struct)
%:53:5:    ├── session (Field)
%:54:9:    ├── buf (Field)
%:55:5:    ├── offset (Field)
%:56:5:    └── state (Field)
%:59:6:    impl ParserState (Object)
%:60:12:   └── new (Function)
%:70:4:    next_string (Function)
%:85:4:    process (Function)
%:113:7:   FromString (Interface)
%:114:10:  ├── Err (TypeParameter)
%:115:8:   └── from_string (Function)
...
```

After:
```
src/controller.rs
%:46:6:    enum QuoteState
%:47:5:    ├── OutsideArg
%:48:5:    ├── InsideArg
%:49:5:    └── InsideArgSQ
%:52:12:   struct ParserState
%:53:5:    ├── session
%:54:9:    ├── buf
%:55:5:    ├── offset
%:56:5:    └── state
%:59:6:    impl ParserState
%:60:12:   └── fn new
%:70:4:    fn next_string
%:85:4:    fn process
%:113:7:   trait FromString
%:114:10:  ├── type Err
%:115:8:   └── fn from_string
...
```