### PR TITLE
Scala Metals: turn off Unicode icons until Kakoune can handle emoji width

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -464,10 +464,10 @@ hook -group lsp-filetype-scala global BufSetOption filetype=scala %{
         args = ["-Dmetals.extensions=false"]
         settings_section = "metals"
         [metals.settings.metals]
-        icons = "unicode"
+        icons = "none"
         isHttpEnabled = true
         statusBarProvider = "show-message"
-        compilerOptions = { overrideDefFormat = "unicode" }
+        compilerOptions = { overrideDefFormat = "ascii" }
         inlayHints.hintsInPatternMatch.enable = true
         inlayHints.implicitArguments.enable = true
         inlayHints.implicitConversions.enable = true


### PR DESCRIPTION
As reported in [^1], we have configured Scala Metals to use Unicode
symbols for window/showMessage which are displayed in the status line.
Kakoune does not yet know that emoji are width 2, which causes visual
glitches.

Unfortunately fixing Kakoune is not completely trivial because they
don't use wcswidth() but only wcwidth(); this means that we'd need to
adjust the code to lookahead by one codepoint to detect any VARIATION
SELECTOR-16.

Until we fix this, let's switch back to the defaults, e.g. no emoji.

Alternatively, we could use logMessage to move away from the status
line into the debug buffer but that has the same problem, it's just
less visible.

cc @igor-ramazanov

[^1]: https://github.com/kakoune-lsp/kakoune-lsp/pull/794#discussion_r1821986637
