### PR TITLE
add default configuration for tinymist

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -2286,6 +2286,7 @@ define-command -hidden lsp-diagnostics-open-error -params 4 %{
 }
 
 declare-option -docstring 'name of the client in which documentation is to be displayed' str docsclient
+declare-option -docstring "maximum amount of characters per line, after which a newline character will be inserted" int autowrap_column 80
 
 hook global -once KakBegin .* %{
     try %{

--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -511,6 +511,21 @@ hook -group lsp-filetype-toml global BufSetOption filetype=toml %{
     }
 }
 
+hook -group lsp-filetype-typst global BufSetOption filetype=typst %{
+    set-option buffer lsp_servers %exp{
+        [tinymist]
+        root_globs = [".git", ".hg"]
+        args = ["lsp"]
+        settings_section = "tinymist"
+        [tinymist.settings.tinymist]
+        # See https://myriad-dreamin.github.io/tinymist/configurations.html
+        exportPdf = "onDocumentHasTitle"
+        formatterMode = "typstyle"
+        formatterPrintWidth = %opt{autowrap_column}
+        previewFeature = "disable"
+    }
+}
+
 hook -group lsp-filetype-yaml global BufSetOption filetype=yaml %{
     set-option buffer lsp_servers %{
         [yaml-language-server]

--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -512,18 +512,18 @@ hook -group lsp-filetype-toml global BufSetOption filetype=toml %{
 }
 
 hook -group lsp-filetype-typst global BufSetOption filetype=typst %{
-    set-option buffer lsp_servers %exp{
+    set-option buffer lsp_servers %{
         [tinymist]
         root_globs = [".git", ".hg"]
         args = ["lsp"]
-        settings_section = "tinymist"
-        [tinymist.settings.tinymist]
+        settings_section = "_"
+        [tinymist.settings._]
         # See https://myriad-dreamin.github.io/tinymist/configurations.html
         exportPdf = "onDocumentHasTitle"
         formatterMode = "typstyle"
-        formatterPrintWidth = %opt{autowrap_column}
         previewFeature = "disable"
     }
+    set-option -add buffer lsp_servers "formatterPrintWidth = %opt{autowrap_column}"
 }
 
 hook -group lsp-filetype-yaml global BufSetOption filetype=yaml %{


### PR DESCRIPTION
includes an expansion to set the formatter column width. preview is disabled due to being experimental.