### PR TITLE
Add support for vuejs

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -208,6 +208,24 @@ hook -group lsp-filetype-html global BufSetOption filetype=html %{
     }
 }
 
+hook -group lsp-filetype-vue global BufSetOption filetype=(?:vue) %{
+    set-option buffer lsp_servers %{
+        [typescript-language-server]
+        root_globs = ["package.json", "tsconfig.json", "jsconfig.json", ".git", ".hg"]
+        args = ["--stdio"]
+        settings_section = "_"
+        [typescript-language-server.settings._]
+        plugins = [{ name = "@vue/typescript-plugin", location = "vue-language-server", languages = ["vue"] }]
+    }
+    # set-option buffer lsp_servers %{
+    #     [tailwindcss-language-server]
+    #     root_globs = ["tailwind.*"]
+    #     args = ["--stdio"]
+    #     [tailwindcss-language-server.settings.tailwindCSS]
+    #     editor = {}
+    # }
+}
+
 hook -group lsp-filetype-javascript global BufSetOption filetype=(?:javascript|typescript) %{
     set-option buffer lsp_servers %{
         [typescript-language-server]


### PR DESCRIPTION
Hi!

This PR adds vuejs support. It is based on:

https://www.npmjs.com/package/@vue/typescript-plugin

The reason I set `location` to `vue-language-server` rather than `"/usr/local/lib/node_modules/@vue/language-server"` as documented in the npm package is because the latter won't work with nix.